### PR TITLE
display: hdmi|fbdev: fix [RDK-431] uninitialized data and parameter h…

### DIFF
--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
@@ -666,10 +666,15 @@ int LT8618SXB_Read_EDID(hobot_hdmi_sync_t * sync)
 				}
 				if (i == 3) {
 					if (extended_flag < 1) { //no block 1, stop reading edid.
+						memset(&edid_raw_data, 0, sizeof(edid_raw_t));
+						memcpy(&edid_raw_data.edid_data, Sink_EDID, 256*sizeof(uint8_t));
+						memcpy(&edid_raw_data.edid_data2,Sink_EDID2,256*sizeof(uint8_t));
+						edid_raw_data.block_num = 0; // main block only
+						// printk("edid_raw_data.block_num = %d\n", edid_raw_data.block_num);
 						hobot_write_lt8618sxb(0x03, 0xc2);
 						hobot_write_lt8618sxb(0x07, 0x1f);
 						pr_debug("EDID:Only 1 block\n");
-						//printk("LT8618SXB_Read_EDID 11 out\n");
+						printk("LT8618SXB_Read_EDID 11 out\n");
 						return 0;
 					}
 				}

--- a/drivers/video/fbdev/hobot_fb.c
+++ b/drivers/video/fbdev/hobot_fb.c
@@ -614,12 +614,12 @@ static int hbfb_set_par(struct fb_info *info)
 		info->var.bits_per_pixel = 24;
 	}
 
-	user_config(1920,info->var.yres_virtual,info->var.xres,info->var.yres);
+	user_config(info->var.xres_virtual,info->var.yres_virtual,info->var.xres,info->var.yres);
 	if(ubuntu_desktop == 0){
 		info->fix.line_length = get_line_length(info->var.xres_virtual,24);
 
 	}else{
-		info->fix.line_length = get_line_length(1920,24);
+		info->fix.line_length = get_line_length(info->var.xres_virtual,24);
 		memcpy(&store_chn_cfg,&channel_base_cfg[0],sizeof(channel_base_cfg_t));
 	}
 	iar_timing.hfp = info->var.right_margin;
@@ -1114,16 +1114,12 @@ static int hbfb_probe(struct platform_device *pdev)
 	framebuf_user1 = *hobot_iar_get_framebuf_addr(3);
 	pr_debug("framebuf_user.paddr = 0x%llx\n", framebuf_user.paddr);
 	pr_debug("framebuf_uset.vaddr = 0x%p\n", framebuf_user.vaddr);
-
-	frame_size = IAR_MAX_HEIGHT * IAR_MAX_WIDTH * 4; //RGBA 
-	
 	pr_debug("frame_size is %d\n", frame_size);
-
-
 
 	fb_fix_default.smem_start = framebuf_user.paddr;
 
 	hobot_fbi->fb.var = fb_var_default;
+	frame_size = IAR_MAX_HEIGHT * IAR_MAX_WIDTH * 4; //RGBA
 
 	//We assume that the output mode at this time is bt1120 and try to get edid.
 	if (1)


### PR DESCRIPTION
…andling

Summay:
In HDMI driver:
- Initialize edid_raw_data when no extended block exists
- Added memset/memcpy to prevent using uninitialized data
- Changed debug print to ensure log visibility

In FBDEV driver:
- Use dynamic resolution parameters instead of fixed values
- Replaced hardcoded 1920 with xres_virtual variable
- Fixed line_length calculation to use virtual width
- Adjusted frame_size initialization order in probe