### PR TITLE
misc: bt2hdmi-lt: feat [RDK-708] add ioctl to report HDMI HPD connection

### DIFF
--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb.h
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb.h
@@ -92,6 +92,8 @@ typedef struct edid_raw
 extern edid_raw_t edid_raw_data;
 extern int LT8618SXB_Chip_ID(void);
 extern void LT8618SX_Initial(void);
+/* Return 1 when HDMI/HPD is detected high, else 0. */
+extern u8 LT8618SXB_HPD_status(void);
 void Resolution_change(hobot_hdmi_sync_t* timing);
 int LT8618SXB_Read_EDID(hobot_hdmi_sync_t * sync);
 #endif

--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_dev.c
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_dev.c
@@ -81,6 +81,8 @@ typedef struct hdmi_timing
 #define LT8618_GET_EDID_RESOLUTION_RATIO LT8618_IOR(100, hobot_hdmi_sync_t)
 #define LT8618_GET_EDID_RAW LT8618_IOR(103, edid_raw_t)
 #define LT8618_SET_EDID_TIMING LT8618_IOW(102, hdmi_timing_t)
+/* Get HDMI connected status (HPD high => 1, else 0) */
+#define LT8618_GET_HDMI_CONNECTED LT8618_IOR(106, unsigned int)
 // #define LT8618_SET_POLARITY	    LT8618_IOW(102, unsigned int)
 // #define LT8618_GET_POLARITY		LT8618_IOR(103, unsigned int)
 // #define LT8618_ENABLE	        LT8618_IO(104)
@@ -139,6 +141,15 @@ static long lt8618_ioctl(struct file *file, unsigned int cmd,
 	case LT8618_GET_EDID_RAW:
 	{
 		if (copy_to_user((void __user *)arg, &edid_raw_data, sizeof(edid_raw_t)))
+			r = -EFAULT;
+		break;
+	}
+	case LT8618_GET_HDMI_CONNECTED:
+	{
+		unsigned int connected = 0;
+		u8 hpd = LT8618SXB_HPD_status();
+		connected = (hpd != 0) ? 1 : 0;
+		if (copy_to_user((void __user *)arg, &connected, sizeof(unsigned int)))
 			r = -EFAULT;
 		break;
 	}


### PR DESCRIPTION
Summary:
- Export LT8618SXB_HPD_status() in the header for ioctl and other callers.
- Add LT8618_GET_HDMI_CONNECTED (IOR 106) and handle it in lt8618_ioctl.
- Return 1 when HPD is high and 0 otherwise, with copy_to_user to userspace.