### PR TITLE
display: hdmi: fix [RDK-803] Mute TX during resolution transitions

### DIFF
--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
@@ -1819,8 +1819,83 @@ int hdmi_get_edid(void *param){
 	return ret;
 }
 EXPORT_SYMBOL(hdmi_get_edid);
-void hdmi_set_resolution(hobot_hdmi_sync_t* user_timing){
-	Resolution_change(user_timing);
+
+/*
+ * Transition policy for modeset stripe issue.
+ * 0: disabled
+ * 1: DMT only (vic == 0) [default]
+ * 2: all modes
+ */
+static int hdmi_transition_policy = 1;
+module_param_named(hdmi_transition, hdmi_transition_policy, int, 0644);
+MODULE_PARM_DESC(hdmi_transition,
+	"LT8618 modeset transition: 0=off, 1=DMT only(vic==0), 2=all modes");
+
+static bool lt8618sxb_timing_equal(const hobot_hdmi_sync_t *a,
+				  const hobot_hdmi_sync_t *b)
+{
+	return a->hfp == b->hfp &&
+	       a->hs == b->hs &&
+	       a->hbp == b->hbp &&
+	       a->hact == b->hact &&
+	       a->vfp == b->vfp &&
+	       a->vs == b->vs &&
+	       a->vbp == b->vbp &&
+	       a->vact == b->vact &&
+	       a->clk == b->clk &&
+	       a->vic == b->vic;
+}
+
+void hdmi_set_resolution(hobot_hdmi_sync_t* user_timing)
+{
+	bool need_transition = false;
+	bool mode_changed = true;
+	static bool last_valid;
+	static hobot_hdmi_sync_t last_timing;
+
+	if (!user_timing)
+		return;
+
+	if (last_valid)
+		mode_changed = !lt8618sxb_timing_equal(user_timing, &last_timing);
+
+	/* Decide transition by policy, and avoid doing it when timing is unchanged. */
+	if (mode_changed) {
+		if (hdmi_transition_policy >= 2) {
+			need_transition = true;
+		} else if (hdmi_transition_policy == 1) {
+			need_transition = (user_timing->vic == 0);
+		}
+	}
+
+	if (g_x2_lt8618sxb)
+		mutex_lock(&g_x2_lt8618sxb->lt8618sxb_mutex);
+
+	if (need_transition) {
+		/* Mute HDMI TX output to avoid sink sampling unstable frames. */
+		LT8618SXB_HDMI_TX_En(false);
+		msleep(80);
+
+		/* Reset internal video process logic before applying new timing. */
+		LT8618SXB_RST_PD_Init();
+		msleep(20);
+
+		Resolution_change(user_timing);
+		msleep(120);
+
+		/* Re-enable TX after timing/PLL has settled. */
+		LT8618SXB_HDMI_TX_En(true);
+		msleep(80);
+	} else {
+		Resolution_change(user_timing);
+	}
+
+	/* Remember last timing to avoid repeated transition on no-op sets. */
+	last_timing = *user_timing;
+	last_valid = true;
+
+	if (g_x2_lt8618sxb)
+		mutex_unlock(&g_x2_lt8618sxb->lt8618sxb_mutex);
 }
 EXPORT_SYMBOL(hdmi_set_resolution);
 /***********************************************************

--- a/drivers/video/fbdev/hobot_fb.c
+++ b/drivers/video/fbdev/hobot_fb.c
@@ -603,12 +603,10 @@ int user_config(uint32_t src_w, uint32_t src_h,uint32_t dst_w, uint32_t dst_h)
 static int hbfb_set_par(struct fb_info *info)
 {
 	// dump_stack();
-	int ret = 0;
 	unsigned int layer_width = 0;
 	unsigned int layer_height = 0;
 	struct disp_timing iar_timing;
 	hobot_hdmi_sync_t hdmi_timing;
-	uint64_t iar_pixel_clk = 0;
 	extern channel_base_cfg_t store_chn_cfg;
 	if (info->var.bits_per_pixel == 32) {
 		info->var.bits_per_pixel = 24;
@@ -631,10 +629,9 @@ static int hbfb_set_par(struct fb_info *info)
 	iar_timing.vfp_cnt = 0X0;
 
 	disp_set_panel_timing(&iar_timing);
-	
+	disp_set_pixel_clk(info->var.pixclock ?
+			   1000000000000ULL / info->var.pixclock : 0);
 
-	disp_set_pixel_clk(1000000000000 / info->var.pixclock);
-	
 	if (enable_sif_mclk() != 0)
 		return -1;
 	if (iar_pixel_clk_enable() != 0)


### PR DESCRIPTION
Summary:
When changing mode, optionally mute LT8618 HDMI TX, delay, run LT8618SXB_RST_PD_Init(), apply Resolution_change(), then unmute after PLL/timing settle. Add hdmi_transition module param (off / DMT vic==0 / all modes) and lt8618sxb_timing_equal() to skip redundant transitions; hold lt8618sxb_mutex across the path.